### PR TITLE
Adding KairosDB output plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,6 +350,7 @@ For documentation on the latest development code see the [documentation index][d
 * [http](./plugins/outputs/http)
 * [instrumental](./plugins/outputs/instrumental)
 * [kafka](./plugins/outputs/kafka)
+* [kairosdb](./plugins/outputs/kairosdb)
 * [librato](./plugins/outputs/librato)
 * [mqtt](./plugins/outputs/mqtt)
 * [nats](./plugins/outputs/nats)

--- a/etc/telegraf.conf
+++ b/etc/telegraf.conf
@@ -929,6 +929,35 @@
 #   separator = "_"
 
 
+# # Configuration for KairosDB server to send metrics to
+# [[outputs.kairosdb]]
+#   ## prefix for metrics keys
+#   prefix = "my.specific.prefix."
+#
+#   ## DNS name of the KairosDB server
+#   ## Using "kairosdb.example.com" or "tcp://kairosdb.example.com" will use the
+#   ## telnet API. "http://kairosdb.example.com" will use the Http API.
+#   host = "kairosdb.example.com"
+#
+#   ## Port of the KairosDB server
+#   ## Telnet uses port 4242, whereas http normally uses 8080.
+#   port = 8080
+#
+#   ## Number of data points to send to KairosDB in Http requests.
+#   ## Not used with telnet API.
+#   http_batch_size = 50
+#
+#   ## URI Path for Http requests to KairosDB.
+#   ## Used in cases where KairosDB is located behind a reverse proxy.
+#   http_path = "/api/put"
+#
+#   ## Debug true - Prints KairosDB communication
+#   debug = false
+#
+#   ## Separator separates measurement name from field
+#   separator = "_"
+
+
 # # Configuration for the Prometheus client to spawn
 # [[outputs.prometheus_client]]
 #   ## Address to listen on

--- a/plugins/outputs/all/all.go
+++ b/plugins/outputs/all/all.go
@@ -19,6 +19,7 @@ import (
 	_ "github.com/influxdata/telegraf/plugins/outputs/influxdb_v2"
 	_ "github.com/influxdata/telegraf/plugins/outputs/instrumental"
 	_ "github.com/influxdata/telegraf/plugins/outputs/kafka"
+	_ "github.com/influxdata/telegraf/plugins/outputs/kairosdb"
 	_ "github.com/influxdata/telegraf/plugins/outputs/kinesis"
 	_ "github.com/influxdata/telegraf/plugins/outputs/librato"
 	_ "github.com/influxdata/telegraf/plugins/outputs/mqtt"

--- a/plugins/outputs/kairosdb/README.md
+++ b/plugins/outputs/kairosdb/README.md
@@ -1,0 +1,48 @@
+# KairosDB Output Plugin
+
+This plugin writes [KairosDB](https://kairosdb.github.io/) using the telnet or http protocols.
+
+KairosDB is a rewrite of OpenTSDB that uses Cassandra as a backend. However, there are several
+differences between their http APIs to warrant a separate plugin. The opentsdb output does not
+work with KairosDB. 
+
+To use Http mode, use 'http://' in the host parameter. Otherwise, use 'tcp://'
+
+See https://kairosdb.github.io/docs/build/html/restapi/AddDataPoints.html fir detauks.
+
+### Configuration:
+
+```toml
+[[outputs.kairosdb]]
+  ## TCP endpoint for writing to the KairosDB telnet interface
+  # host = "tcp://kairosdb.example.com"
+  # port = 4242
+
+  ## HTTP endpoint for writing to the KairosDB REST API
+  host = "http://lkairosdb.example.com"
+  port = 8080
+
+  ## Prefix metrics name
+  prefix = "my.specific.prefix."
+
+  ## Number of data points to send to KairosDB in Http requests.
+  ## Not used with telnet API.
+  http_batch_size = 50
+
+  ## URI Path for Http requests to KairosDB.
+  ## Used in cases where KairosDB is located behind a reverse proxy.
+  http_path = "api/v1/datapoints"
+
+  debug = true
+  separator = "_"
+
+  ## Number of data points to send to KairosDB in Http requests.
+  ## Not used with telnet API.
+  http_batch_size = 50
+
+  ## Debug true - Prints KairosDB communication
+  debug = false
+
+  ## Separator separates measurement name from field
+  separator = "_"
+```

--- a/plugins/outputs/kairosdb/kairosdb.go
+++ b/plugins/outputs/kairosdb/kairosdb.go
@@ -1,0 +1,285 @@
+package kairosdb
+
+import (
+	"fmt"
+	"log"
+	"net"
+	"net/url"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/plugins/outputs"
+)
+
+var (
+	allowedChars = regexp.MustCompile(`[^a-zA-Z0-9-_./\p{L}]`)
+	hypenChars   = strings.NewReplacer(
+		"@", "-",
+		"*", "-",
+		`%`, "-",
+		"#", "-",
+		"$", "-")
+	defaultHttpPath  = "/api/put"
+	defaultSeperator = "_"
+)
+
+type KairosDB struct {
+	Prefix string
+
+	Host string
+	Port int
+
+	HttpBatchSize int // deprecated httpBatchSize form in 1.8
+	HttpPath      string
+
+	Debug bool
+
+	Separator string
+}
+
+var sampleConfig = `
+[[outputs.kairosdb]]
+  ## TCP endpoint for writing to the KairosDB telnet interface
+  # host = "tcp://kairosdb.example.com"
+  # port = 4242
+
+  ## HTTP endpoint for writing to the KairosDB REST API
+  host = "http://lkairosdb.example.com"
+  port = 8080
+
+  ## Prefix metrics name
+  prefix = "my.specific.prefix."
+
+  ## Number of data points to send to KairosDB in Http requests.
+  ## Not used with telnet API.
+  http_batch_size = 50
+
+  ## URI Path for Http requests to KairosDB.
+  ## Used in cases where KairosDB is located behind a reverse proxy.
+  http_path = "api/v1/datapoints"
+
+  debug = true
+  separator = "_"
+
+  ## Number of data points to send to KairosDB in Http requests.
+  ## Not used with telnet API.
+  http_batch_size = 50
+
+  ## Debug true - Prints KairosDB communication
+  debug = false
+
+  ## Separator separates measurement name from field
+  separator = "_"
+`
+
+func ToLineFormat(tags map[string]string) string {
+	tagsArray := make([]string, len(tags))
+	index := 0
+	for k, v := range tags {
+		tagsArray[index] = fmt.Sprintf("%s=%s", k, v)
+		index++
+	}
+	sort.Strings(tagsArray)
+	return strings.Join(tagsArray, " ")
+}
+
+func (o *KairosDB) Connect() error {
+	if !strings.HasPrefix(o.Host, "http") && !strings.HasPrefix(o.Host, "tcp") {
+		o.Host = "tcp://" + o.Host
+	}
+	// Test Connection to KairosDB Server
+	u, err := url.Parse(o.Host)
+	if err != nil {
+		return fmt.Errorf("Error in parsing host url: %s", err.Error())
+	}
+
+	uri := fmt.Sprintf("%s:%d", u.Host, o.Port)
+	tcpAddr, err := net.ResolveTCPAddr("tcp", uri)
+	if err != nil {
+		return fmt.Errorf("KairosDB TCP address cannot be resolved: %s", err)
+	}
+	connection, err := net.DialTCP("tcp", nil, tcpAddr)
+	if err != nil {
+		return fmt.Errorf("KairosDB Telnet connect fail: %s", err)
+	}
+	defer connection.Close()
+	return nil
+}
+
+func (o *KairosDB) Write(metrics []telegraf.Metric) error {
+	if len(metrics) == 0 {
+		return nil
+	}
+
+	u, err := url.Parse(o.Host)
+	if err != nil {
+		return fmt.Errorf("Error in parsing host url: %s", err.Error())
+	}
+
+	if u.Scheme == "" || u.Scheme == "tcp" {
+		return o.WriteTelnet(metrics, u)
+	} else if u.Scheme == "http" || u.Scheme == "https" {
+		return o.WriteHttp(metrics, u)
+	} else {
+		return fmt.Errorf("Unknown scheme in host parameter.")
+	}
+}
+
+func (o *KairosDB) WriteHttp(metrics []telegraf.Metric, u *url.URL) error {
+	http := KairosDBHttp{
+		Host:      u.Host,
+		Port:      o.Port,
+		Scheme:    u.Scheme,
+		User:      u.User,
+		BatchSize: o.HttpBatchSize,
+		Path:      o.HttpPath,
+		Debug:     o.Debug,
+	}
+
+	for _, m := range metrics {
+		now := m.Time().UnixNano() / 1000000
+		tags := cleanTags(m.Tags())
+
+		for fieldName, value := range m.Fields() {
+			switch value.(type) {
+			case int64:
+			case uint64:
+			case float64:
+			default:
+				log.Printf("D! KairosDB does not support metric value: [%s] of type [%T].\n", value, value)
+				continue
+			}
+
+			metric := &HttpMetric{
+				Metric: sanitize(fmt.Sprintf("%s%s%s%s",
+					o.Prefix, m.Name(), o.Separator, fieldName)),
+				Tags:      tags,
+				Timestamp: now,
+				Value:     value,
+			}
+
+			if err := http.sendDataPoint(metric); err != nil {
+				return err
+			}
+		}
+	}
+
+	if err := http.flush(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (o *KairosDB) WriteTelnet(metrics []telegraf.Metric, u *url.URL) error {
+	// Send Data with telnet / socket communication
+	uri := fmt.Sprintf("%s:%d", u.Host, o.Port)
+	tcpAddr, _ := net.ResolveTCPAddr("tcp", uri)
+	connection, err := net.DialTCP("tcp", nil, tcpAddr)
+	if err != nil {
+		return fmt.Errorf("KairosDB: Telnet connect fail")
+	}
+	defer connection.Close()
+
+	for _, m := range metrics {
+		now := m.Time().UnixNano() / 1000000000
+		tags := ToLineFormat(cleanTags(m.Tags()))
+
+		for fieldName, value := range m.Fields() {
+			switch value.(type) {
+			case int64:
+			case uint64:
+			case float64:
+			default:
+				log.Printf("D! KairosDB does not support metric value: [%s] of type [%T].\n", value, value)
+				continue
+			}
+
+			metricValue, buildError := buildValue(value)
+			if buildError != nil {
+				log.Printf("E! KairosDB: %s\n", buildError.Error())
+				continue
+			}
+
+			messageLine := fmt.Sprintf("put %s %v %s %s\n",
+				sanitize(fmt.Sprintf("%s%s%s%s", o.Prefix, m.Name(), o.Separator, fieldName)),
+				now, metricValue, tags)
+
+			_, err := connection.Write([]byte(messageLine))
+			if err != nil {
+				return fmt.Errorf("KairosDB: Telnet writing error %s", err.Error())
+			}
+		}
+	}
+
+	return nil
+}
+
+func cleanTags(tags map[string]string) map[string]string {
+	tagSet := make(map[string]string, len(tags))
+	for k, v := range tags {
+		val := sanitize(v)
+		if val != "" {
+			tagSet[sanitize(k)] = val
+		}
+	}
+	return tagSet
+}
+
+func buildValue(v interface{}) (string, error) {
+	var retv string
+	switch p := v.(type) {
+	case int64:
+		retv = IntToString(int64(p))
+	case uint64:
+		retv = UIntToString(uint64(p))
+	case float64:
+		retv = FloatToString(float64(p))
+	default:
+		return retv, fmt.Errorf("unexpected type %T with value %v for KairosDB", v, v)
+	}
+	return retv, nil
+}
+
+func IntToString(input_num int64) string {
+	return strconv.FormatInt(input_num, 10)
+}
+
+func UIntToString(input_num uint64) string {
+	return strconv.FormatUint(input_num, 10)
+}
+
+func FloatToString(input_num float64) string {
+	return strconv.FormatFloat(input_num, 'f', 6, 64)
+}
+
+func (o *KairosDB) SampleConfig() string {
+	return sampleConfig
+}
+
+func (o *KairosDB) Description() string {
+	return "Configuration for KairosDB server to send metrics to"
+}
+
+func (o *KairosDB) Close() error {
+	return nil
+}
+
+func sanitize(value string) string {
+	// Apply special hypenation rules to preserve backwards compatibility
+	value = hypenChars.Replace(value)
+	// Replace any remaining illegal chars
+	return allowedChars.ReplaceAllLiteralString(value, "_")
+}
+
+func init() {
+	outputs.Add("kairosdb", func() telegraf.Output {
+		return &KairosDB{
+			HttpPath:  defaultHttpPath,
+			Separator: defaultSeperator,
+		}
+	})
+}

--- a/plugins/outputs/kairosdb/kairosdb_http.go
+++ b/plugins/outputs/kairosdb/kairosdb_http.go
@@ -1,0 +1,180 @@
+package kairosdb
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+)
+
+type HttpMetric struct {
+	Metric    string            `json:"name"`
+	Timestamp int64             `json:"timestamp"`
+	Value     interface{}       `json:"value"`
+	Tags      map[string]string `json:"tags"`
+}
+
+type KairosDBBHttp struct {
+	Host      string
+	Port      int
+	Scheme    string
+	User      *url.Userinfo
+	BatchSize int
+	Path      string
+	Debug     bool
+
+	metricCounter int
+	body          requestBody
+}
+
+type requestBody struct {
+	b bytes.Buffer
+	g *gzip.Writer
+
+	dbgB bytes.Buffer
+
+	w   io.Writer
+	enc *json.Encoder
+
+	empty bool
+}
+
+func (r *requestBody) reset(debug bool) {
+	r.b.Reset()
+	r.dbgB.Reset()
+
+	if r.g == nil {
+		r.g = gzip.NewWriter(&r.b)
+	} else {
+		r.g.Reset(&r.b)
+	}
+
+	if debug {
+		r.w = io.MultiWriter(r.g, &r.dbgB)
+	} else {
+		r.w = r.g
+	}
+
+	r.enc = json.NewEncoder(r.w)
+
+	io.WriteString(r.w, "[")
+
+	r.empty = true
+}
+
+func (r *requestBody) addMetric(metric *HttpMetric) error {
+	if !r.empty {
+		io.WriteString(r.w, ",")
+	}
+
+	if err := r.enc.Encode(metric); err != nil {
+		return fmt.Errorf("Metric serialization error %s", err.Error())
+	}
+
+	r.empty = false
+
+	return nil
+}
+
+func (r *requestBody) close() error {
+	io.WriteString(r.w, "]")
+
+	if err := r.g.Close(); err != nil {
+		return fmt.Errorf("Error when closing gzip writer: %s", err.Error())
+	}
+
+	return nil
+}
+
+func (o *KairosDBHttp) sendDataPoint(metric *HttpMetric) error {
+	if o.metricCounter == 0 {
+		o.body.reset(o.Debug)
+	}
+
+	if err := o.body.addMetric(metric); err != nil {
+		return err
+	}
+
+	o.metricCounter++
+	if o.metricCounter == o.BatchSize {
+		if err := o.flush(); err != nil {
+			return err
+		}
+
+		o.metricCounter = 0
+	}
+
+	return nil
+}
+
+func (o *KairosDBHttp) flush() error {
+	if o.metricCounter == 0 {
+		return nil
+	}
+
+	o.body.close()
+
+	u := url.URL{
+		Scheme: o.Scheme,
+		User:   o.User,
+		Host:   fmt.Sprintf("%s:%d", o.Host, o.Port),
+		Path:   o.Path,
+	}
+
+	if o.Debug {
+		u.RawQuery = "details"
+	}
+
+	req, err := http.NewRequest("POST", u.String(), &o.body.b)
+	if err != nil {
+		return fmt.Errorf("Error when building request: %s", err.Error())
+	}
+	req.Header.Set("Content-Type", "application/gzip")
+	req.Header.Set("Content-Encoding", "identity")
+
+	if o.Debug {
+		dump, err := httputil.DumpRequestOut(req, false)
+		if err != nil {
+			return fmt.Errorf("Error when dumping request: %s", err.Error())
+		}
+
+		fmt.Printf("Sending metrics:\n%s", dump)
+		fmt.Printf("Body:\n%s\n\n", o.body.dbgB.String())
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("Error when sending metrics: %s", err.Error())
+	}
+	defer resp.Body.Close()
+
+	if o.Debug {
+		dump, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return fmt.Errorf("Error when dumping response: %s", err.Error())
+		}
+
+		fmt.Printf("Received response\n%s\n\n", dump)
+	} else {
+		// Important so http client reuse connection for next request if need be.
+		io.Copy(ioutil.Discard, resp.Body)
+	}
+
+	if resp.StatusCode/100 != 2 {
+		if resp.StatusCode/100 == 4 {
+			log.Printf("E! Received %d status code. Dropping metrics to avoid overflowing buffer.",
+				resp.StatusCode)
+		} else {
+			return fmt.Errorf("Error when sending metrics. Received status %d",
+				resp.StatusCode)
+		}
+	}
+
+	return nil
+}

--- a/plugins/outputs/kairosdb/kairosdb_test.go
+++ b/plugins/outputs/kairosdb/kairosdb_test.go
@@ -1,0 +1,204 @@
+package kairosdb
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"reflect"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/testutil"
+)
+
+func TestCleanTags(t *testing.T) {
+	var tagtests = []struct {
+		ptIn    map[string]string
+		outTags map[string]string
+	}{
+		{
+			map[string]string{"one": "two", "three": "four"},
+			map[string]string{"one": "two", "three": "four"},
+		},
+		{
+			map[string]string{"aaa": "bbb"},
+			map[string]string{"aaa": "bbb"},
+		},
+		{
+			map[string]string{"Sp%ci@l Chars[": "g$t repl#ce)d"},
+			map[string]string{"Sp-ci-l_Chars_": "g-t_repl-ce_d"},
+		},
+		{
+			map[string]string{"μnicodε_letters": "okαy"},
+			map[string]string{"μnicodε_letters": "okαy"},
+		},
+		{
+			map[string]string{"n☺": "emojies☠"},
+			map[string]string{"n_": "emojies_"},
+		},
+		{
+			map[string]string{},
+			map[string]string{},
+		},
+	}
+	for _, tt := range tagtests {
+		tags := cleanTags(tt.ptIn)
+		if !reflect.DeepEqual(tags, tt.outTags) {
+			t.Errorf("\nexpected %+v\ngot %+v\n", tt.outTags, tags)
+		}
+	}
+}
+
+func TestBuildTagsTelnet(t *testing.T) {
+	var tagtests = []struct {
+		ptIn    map[string]string
+		outTags string
+	}{
+		{
+			map[string]string{"one": "two", "three": "four"},
+			"one=two three=four",
+		},
+		{
+			map[string]string{"aaa": "bbb"},
+			"aaa=bbb",
+		},
+		{
+			map[string]string{"one": "two", "aaa": "bbb"},
+			"aaa=bbb one=two",
+		},
+		{
+			map[string]string{},
+			"",
+		},
+	}
+	for _, tt := range tagtests {
+		tags := ToLineFormat(tt.ptIn)
+		if !reflect.DeepEqual(tags, tt.outTags) {
+			t.Errorf("\nexpected %+v\ngot %+v\n", tt.outTags, tags)
+		}
+	}
+}
+
+func TestSanitize(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    string
+		expected string
+	}{
+		{
+			name:     "Ascii letters and numbers allowed",
+			value:    "ascii 123",
+			expected: "ascii_123",
+		},
+		{
+			name:     "Allowed punct",
+			value:    "-_./",
+			expected: "-_./",
+		},
+		{
+			name:     "Special conversions to hyphen",
+			value:    "@*%#$!",
+			expected: "-----_",
+		},
+		{
+			name:     "Unicode Letters allowed",
+			value:    "μnicodε_letters",
+			expected: "μnicodε_letters",
+		},
+		{
+			name:     "Other Unicode not allowed",
+			value:    "“☢”",
+			expected: "___",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := sanitize(tt.value)
+			require.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
+func BenchmarkHttpSend(b *testing.B) {
+	const BatchSize = 50
+	const MetricsCount = 4 * BatchSize
+	metrics := make([]telegraf.Metric, MetricsCount)
+	for i := 0; i < MetricsCount; i++ {
+		metrics[i] = testutil.TestMetric(1.0)
+	}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintln(w, "{}")
+	}))
+	defer ts.Close()
+
+	u, err := url.Parse(ts.URL)
+	if err != nil {
+		panic(err)
+	}
+
+	_, p, _ := net.SplitHostPort(u.Host)
+
+	port, err := strconv.Atoi(p)
+	if err != nil {
+		panic(err)
+	}
+
+	o := &KairosDB{
+		Host:          ts.URL,
+		Port:          port,
+		Prefix:        "",
+		HttpBatchSize: BatchSize,
+		HttpPath:      "/api/put",
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		o.Write(metrics)
+	}
+}
+
+// func TestWrite(t *testing.T) {
+// 	if testing.Short() {
+// 		t.Skip("Skipping integration test in short mode")
+// 	}
+
+// 	o := &KairosDB{
+// 		Host:   testutil.GetLocalHost(),
+// 		Port:   4242,
+// 		Prefix: "prefix.test.",
+// 	}
+
+// 	// Verify that we can connect to the KairosDB instance
+// 	err := o.Connect()
+// 	require.NoError(t, err)
+
+// 	// Verify that we can successfully write data to KairosDB
+// 	err = o.Write(testutil.MockMetrics())
+// 	require.NoError(t, err)
+
+// 	// Verify positive and negative test cases of writing data
+// 	metrics := testutil.MockMetrics()
+// 	metrics = append(metrics, testutil.TestMetric(float64(1.0),
+// 		"justametric.float"))
+// 	metrics = append(metrics, testutil.TestMetric(int64(123456789),
+// 		"justametric.int"))
+// 	metrics = append(metrics, testutil.TestMetric(uint64(123456789012345),
+// 		"justametric.uint"))
+// 	metrics = append(metrics, testutil.TestMetric("Lorem Ipsum",
+// 		"justametric.string"))
+// 	metrics = append(metrics, testutil.TestMetric(float64(42.0),
+// 		"justametric.anotherfloat"))
+// 	metrics = append(metrics, testutil.TestMetric(float64(42.0),
+// 		"metric w/ specialchars"))
+
+// 	err = o.Write(metrics)
+// 	require.NoError(t, err)
+// }


### PR DESCRIPTION
Adding KairosDB output plugin to Telegraf. I forked this directly from the OpenTSDB output plugin, which does not work with Telegraf due to a small number of differences.